### PR TITLE
feat: implement build-time version injection system

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,8 +26,8 @@ builds:
     ldflags:
       - -s -w
       - -X main.version={{ .Version }}
-      - -X main.build={{ .Date }}
-      - -X main.commit={{ .Commit }}
+      - -X main.date={{ .Date }}
+      - -X main.commit={{ .ShortCommit }}
     tags:
       - netgo
       - osusergo

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG COMMIT_SHA
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     go build \
     -trimpath \
-    -ldflags="-w -s -X main.version=${VERSION} -X main.build=${BUILD_DATE} -X main.commit=${COMMIT_SHA}" \
+    -ldflags="-w -s -X main.version=${VERSION} -X main.commit=${COMMIT_SHA} -X main.date=${BUILD_DATE}" \
     -tags=netgo,osusergo \
     -o /app/namira-core \
     ./cmd/namira-core/ \

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Usage: make [target]
 Targets:
 build                Build Docker containers without starting them
 build-local          Build the Go binary locally
+build-release        Build optimized release binary
 clean                Clean up Docker resources and build artifacts
 dev                  Start development environment with Docker Compose
 docker-build         Build Docker image
@@ -265,6 +266,7 @@ run-local            Run the application locally
 test                 Run all tests / Coming Soon 
 test-coverage        Run tests with coverage / Coming Soon 
 up                   Start Docker Compose services
+version              Show version information
 ```
 
 
@@ -275,6 +277,9 @@ The CLI provides a powerful interface for batch checking VPN configurations with
 ### Basic Usage
 
 ```bash
+# Show version
+./bin/namira-core --version
+
 # Display help
 ./bin/namira-core check --help
 

--- a/cmd/namira-core/api.go
+++ b/cmd/namira-core/api.go
@@ -153,6 +153,14 @@ func runAPIServer(cmd *cobra.Command, args []string) {
 		TaskQueueSize: cfg.Worker.QueueSize,
 	})
 
+	versionInfo := api.VersionInfo{
+		Version:   version,
+		Commit:    commit,
+		Date:      date,
+		GoVersion: goVersion,
+		Platform:  platform,
+	}
+
 	router := api.NewRouter(
 		coreInstance,
 		redisClient,
@@ -160,7 +168,8 @@ func runAPIServer(cmd *cobra.Command, args []string) {
 		telegramConfigResultHandler,
 		logger,
 		updater,
-		worker)
+		worker,
+		versionInfo)
 
 	serverAddr := fmt.Sprintf("%s:%s", cfg.Server.Host, cfg.Server.Port)
 	server := &http.Server{

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -13,9 +13,9 @@ import (
 	"go.uber.org/zap"
 )
 
-func NewRouter(c *core.Core, redisClient *redis.Client, callbackHandler CallbackHandler, configSuccessHandler ConfigSuccessHandler, logger *zap.Logger, updater *github.Updater, worker *workerpool.WorkerPool) *mux.Router {
+func NewRouter(c *core.Core, redisClient *redis.Client, callbackHandler CallbackHandler, configSuccessHandler ConfigSuccessHandler, logger *zap.Logger, updater *github.Updater, worker *workerpool.WorkerPool, versionInfo VersionInfo) *mux.Router {
 	r := mux.NewRouter()
-	h := NewHandler(c, redisClient, callbackHandler, configSuccessHandler, logger, updater, worker)
+	h := NewHandler(c, redisClient, callbackHandler, configSuccessHandler, logger, updater, worker, versionInfo)
 
 	r.Use(corsMiddleware, authMiddleware, loggingMiddleware)
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -77,10 +77,27 @@ type WorkerPoolStatus struct {
 	Uptime         string `json:"uptime"`
 }
 
+type BuildInfo struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	Date      string `json:"date"`
+	GoVersion string `json:"go_version"`
+	Platform  string `json:"platform"`
+}
+
 type HealthResponse struct {
 	Status     string           `json:"status"`
 	Version    string           `json:"version"`
+	Build      BuildInfo        `json:"build"`
 	WorkerPool WorkerPoolStatus `json:"worker_pool"`
+}
+
+type VersionInfo struct {
+	Version   string
+	Commit    string
+	Date      string
+	GoVersion string
+	Platform  string
 }
 
 func NewJob(configs []string) *Job {


### PR DESCRIPTION
## 🎯 Overview

This PR implements a professional build-time version injection system for namira-core.

## ✨ Features

- **Build-time version injection** via ldflags
- **API version endpoints** with detailed build info
- **CLI version command** with formatted output
- **Docker version support** with proper labels
- **GoReleaser integration** for automated releases
- **Development defaults** (version=dev, commit=unknown)

## 🔧 Changes

- Add version variables to main package
- Integrate version info into API handlers
- Update build system (Makefile, Docker, GoReleaser)
- Enhance health endpoint with build information
- Add version command and help improvements

## 🧪 Testing

```bash
# Test version display
make version
make build-local
./bin/namira-core --version

# Test API health endpoint
make dev
curl http://localhost:8080/health | jq '.build'
```

## 📋 Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves existing functionality)
- [x] Documentation update