### PR TITLE
Feat: add XHTTP support for checks

### DIFF
--- a/internal/core/checker/v2ray.go
+++ b/internal/core/checker/v2ray.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/xtls/xray-core/proxy/socks"
 	_ "github.com/xtls/xray-core/proxy/vless"
 	_ "github.com/xtls/xray-core/transport/internet/grpc"
+	_ "github.com/xtls/xray-core/transport/internet/splithttp"
 	_ "github.com/xtls/xray-core/transport/internet/tcp"
 	_ "github.com/xtls/xray-core/transport/internet/udp"
 )

--- a/internal/core/parser/vless.go
+++ b/internal/core/parser/vless.go
@@ -10,23 +10,25 @@ import (
 )
 
 type vlessConfig struct {
-	Raw         string `json:"-"`
-	Server      string `json:"server"`
-	Port        int    `json:"port"`
-	ID          string `json:"id"`
-	Encryption  string `json:"encryption"`
-	Flow        string `json:"flow,omitempty"`
-	Security    string `json:"security,omitempty"`
-	SNI         string `json:"sni,omitempty"`
-	ALPN        string `json:"alpn,omitempty"`
-	Network     string `json:"network"`
-	Type        string `json:"type,omitempty"`
-	Host        string `json:"host,omitempty"`
-	Path        string `json:"path,omitempty"`
-	Mode        string `json:"mode,omitempty"`
-	Authority   string `json:"authority,omitempty"`
-	ServiceName string `json:"serviceName,omitempty"`
-	Remark      string `json:"remark,omitempty"`
+	Raw         string                 `json:"-"`
+	Server      string                 `json:"server"`
+	Port        int                    `json:"port"`
+	ID          string                 `json:"id"`
+	Encryption  string                 `json:"encryption"`
+	Flow        string                 `json:"flow,omitempty"`
+	Security    string                 `json:"security,omitempty"`
+	SNI         string                 `json:"sni,omitempty"`
+	ALPN        string                 `json:"alpn,omitempty"`
+	Network     string                 `json:"network"`
+	Type        string                 `json:"type,omitempty"`
+	Host        string                 `json:"host,omitempty"`
+	Path        string                 `json:"path,omitempty"`
+	Mode        string                 `json:"mode,omitempty"`
+	Authority   string                 `json:"authority,omitempty"`
+	ServiceName string                 `json:"serviceName,omitempty"`
+	Remark      string                 `json:"remark,omitempty"`
+	Fingerprint string                 `json:"fp,omitempty"`
+	Extra       map[string]interface{} `json:"extra,omitempty"`
 }
 
 type vlessJSONUser struct {

--- a/internal/core/parser/vless.go
+++ b/internal/core/parser/vless.go
@@ -44,15 +44,16 @@ type vlessJSONVnext struct {
 }
 
 type vlessJSONStreamSettings struct {
-	Network      string                 `json:"network"`
-	Security     string                 `json:"security,omitempty"`
-	WSSettings   map[string]interface{} `json:"wsSettings,omitempty"`
-	TCPSettings  map[string]interface{} `json:"tcpSettings,omitempty"`
-	KCPSettings  map[string]interface{} `json:"kcpSettings,omitempty"`
-	HTTPSettings map[string]interface{} `json:"httpSettings,omitempty"`
-	QUICSettings map[string]interface{} `json:"quicSettings,omitempty"`
-	GRPCSettings map[string]interface{} `json:"grpcSettings,omitempty"`
-	TLSSettings  map[string]interface{} `json:"tlsSettings,omitempty"`
+	Network       string                 `json:"network"`
+	Security      string                 `json:"security,omitempty"`
+	WSSettings    map[string]interface{} `json:"wsSettings,omitempty"`
+	TCPSettings   map[string]interface{} `json:"tcpSettings,omitempty"`
+	KCPSettings   map[string]interface{} `json:"kcpSettings,omitempty"`
+	HTTPSettings  map[string]interface{} `json:"httpSettings,omitempty"`
+	QUICSettings  map[string]interface{} `json:"quicSettings,omitempty"`
+	GRPCSettings  map[string]interface{} `json:"grpcSettings,omitempty"`
+	TLSSettings   map[string]interface{} `json:"tlsSettings,omitempty"`
+	XHTTPSettings map[string]interface{} `json:"xhttpSettings,omitempty"`
 }
 
 type vlessJSONSettings struct {
@@ -153,6 +154,22 @@ func (c *vlessConfig) MarshalJSON() ([]byte, error) {
 			grpcSettings["multiMode"] = (c.Mode == "multi")
 		}
 		streamSettings.GRPCSettings = grpcSettings
+	case "xhttp":
+		xhttpSettings := make(map[string]interface{})
+		if c.Host != "" {
+			xhttpSettings["host"] = c.Host
+		}
+		if c.Path != "" {
+			xhttpSettings["path"] = c.Path
+		}
+		if c.Mode != "" {
+			xhttpSettings["mode"] = c.Mode
+		}
+		// merge extra fields (scMaxEachPostBytes, noGRPCHeader, etc.)
+		for k, v := range c.Extra {
+			xhttpSettings[k] = v
+		}
+		streamSettings.XHTTPSettings = xhttpSettings
 	}
 
 	switch c.Security {

--- a/internal/core/parser/vless.go
+++ b/internal/core/parser/vless.go
@@ -188,6 +188,10 @@ func (c *vlessConfig) MarshalJSON() ([]byte, error) {
 			}
 			tlsSettings["alpn"] = alpnList
 		}
+		tlsSettings["allowInsecure"] = true
+		if c.Fingerprint != "" {
+			tlsSettings["fingerprint"] = c.Fingerprint
+		}
 		if len(tlsSettings) > 0 {
 			streamSettings.TLSSettings = tlsSettings
 		}
@@ -255,6 +259,10 @@ func parseVless(link string) (Config, error) {
 	if config.Network == "" {
 		config.Network = "tcp"
 	}
+	// normalize xhttp to splithttp (SAME SHIT JUST DIFFERENT NAMES)
+	if config.Network == "splithttp" {
+		config.Network = "xhttp"
+	}
 
 	config.Type = params.Get("headerType")
 	config.Host = params.Get("host")
@@ -262,6 +270,7 @@ func parseVless(link string) (Config, error) {
 	config.Mode = params.Get("mode")
 	config.Authority = params.Get("authority")
 	config.ServiceName = params.Get("serviceName")
+	config.Fingerprint = params.Get("fp")
 
 	if parsedURL.Fragment != "" {
 		config.Remark, _ = url.QueryUnescape(parsedURL.Fragment)


### PR DESCRIPTION
## Description

Added support for `xhttp` (SplitHTTP) transport protocol in the VLESS parser.

Previously, proxies using `type=xhttp` would always fail with `failed to read response: EOF` because:
- The `xhttp` transport was not registered in the Xray instance
- The parser had no handler for `xhttp` in the `streamSettings` switch
- The `extra` URL parameter containing xhttp-specific tuning fields was being ignored
- TLS settings were missing `allowInsecure` and `fingerprint` fields

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes

- Added `_ "github.com/xtls/xray-core/transport/internet/splithttp"` blank import to register the xhttp transport
- Added `xhttp` case to `MarshalJSON` stream settings switch with correct `xhttpSettings` JSON key
- Added parsing of the `extra` URL parameter and merging its fields into `xhttpSettings`
- Added `Fingerprint` field to `vlessConfig` and parsing of `fp` URL parameter
- Added `allowInsecure` and `fingerprint` to TLS settings generation

## How Has This Been Tested?

- [x] Manually tested against multiple `xhttp` VLESS proxies that previously returned EOF
- [x] Verified generated Xray JSON config matches the format exported by v2rayNG GUI
- [x] Confirmed `ws` and other transports still work as expected after changes